### PR TITLE
restrict height of the tooltip to 100%

### DIFF
--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -154,7 +154,10 @@ function positionVertically({
   const mediumOffset = top + height / 2;
 
   const maxSpace = Math.min(mediumOffset, pageHeight - mediumOffset) * 2;
-  const contentHeight = measureHeight(content);
+  // consider padding of the tooltip itself. In case of
+  // overriding styles it will become incorrect
+  // TODO consider padding property
+  const contentHeight = measureHeight(content) + 30;
 
   const positionStyles: { [key: string]: string } = {};
   if (contentHeight >= pageHeight) {

--- a/src/utils/style.ts
+++ b/src/utils/style.ts
@@ -16,6 +16,8 @@ const tooltipStyles = {
   zIndex: "999",
   minWidth: "150px",
   maxWidth: "350px",
+  maxHeight: "100vh",
+  overflowY: "scroll",
   padding: "15px",
   border: "2px solid #ccc",
   borderRadius: "5px",


### PR DESCRIPTION
Before, height can be any – but if we already at the bottom, some content will be just hidden. Instead, now maximum height is only screen size.